### PR TITLE
RT-806: fix TraceId/SpanId.fromString to truncate oversized inputs

### DIFF
--- a/lib/src/api/propagation/w3c_trace_context_propagator.dart
+++ b/lib/src/api/propagation/w3c_trace_context_propagator.dart
@@ -16,8 +16,8 @@ class W3CTraceContextPropagator implements api.TextMapPropagator {
   // for trace parent header specification.
   static final RegExp traceParentHeaderRegEx =
       RegExp('^(?<$_traceVersionFieldKey>[0-9a-f]{2})-'
-          '(?<$_traceIdFieldKey>[0-9a-f]{${api.TraceId.sizeBits}})-'
-          '(?<$_parentIdFieldKey>[0-9a-f]{${api.SpanId.sizeBits}})-'
+          '(?<$_traceIdFieldKey>[0-9a-f]{${api.TraceId.sizeBits},})-'
+          '(?<$_parentIdFieldKey>[0-9a-f]{${api.SpanId.sizeBits},})-'
           '(?<$_traceFlagsFieldKey>[0-9a-f]{${2}})\$');
 
   @override

--- a/lib/src/api/trace/span_id.dart
+++ b/lib/src/api/trace/span_id.dart
@@ -17,8 +17,11 @@ class SpanId {
   }
   SpanId.fromString(String id) {
     _id = [];
-    id = id.padLeft(api.SpanId.sizeBits, '0');
-
+    if (id.length > api.SpanId.sizeBits) {
+      id = id.substring(id.length - api.SpanId.sizeBits);
+    } else {
+      id = id.padLeft(api.SpanId.sizeBits, '0');
+    }
     for (var i = 0; i < id.length; i += 2) {
       _id.add(int.parse('${id[i]}${id[i + 1]}', radix: 16));
     }

--- a/lib/src/api/trace/trace_id.dart
+++ b/lib/src/api/trace/trace_id.dart
@@ -17,8 +17,11 @@ class TraceId {
   }
   TraceId.fromString(String id) {
     _id = [];
-    id = id.padLeft(TraceId.sizeBits, '0');
-
+    if (id.length > TraceId.sizeBits) {
+      id = id.substring(id.length - TraceId.sizeBits);
+    } else {
+      id = id.padLeft(TraceId.sizeBits, '0');
+    }
     for (var i = 0; i < id.length; i += 2) {
       _id.add(int.parse('${id[i]}${id[i + 1]}', radix: 16));
     }

--- a/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
+++ b/test/unit/api/propagation/w3c_trace_context_propagator_test.dart
@@ -236,4 +236,51 @@ void main() {
 
     expect(parentHeaderMatch, isNull);
   });
+
+  // Envoy (Istio sidecar) generates oversized IDs: 48-char trace IDs and
+  // 24-char span IDs.  The propagator must accept and truncate them.
+  test('header regex, oversized trace and parent IDs (Envoy/Istio)', () {
+    // 16 extra leading zeros prepended to a valid 32-char trace ID = 48 chars
+    // 8 extra leading zeros prepended to a valid 16-char span ID = 24 chars
+    const traceParentHeader =
+        '00-00000000000000004bf92f3577b34da6a3ce929d0e0e4736-0000000000f067aa0ba902b7-01';
+    final parentHeaderMatch = api
+        .W3CTraceContextPropagator.traceParentHeaderRegEx
+        .firstMatch(traceParentHeader);
+
+    expect(parentHeaderMatch, isNotNull);
+    final fields = Map<String, String>.fromIterable(
+        parentHeaderMatch.groupNames,
+        key: (element) => element.toString(),
+        value: (element) => parentHeaderMatch.namedGroup(element));
+
+    expect(fields['traceid'],
+        equals('00000000000000004bf92f3577b34da6a3ce929d0e0e4736'));
+    expect(fields['parentid'], equals('0000000000f067aa0ba902b7'));
+  });
+
+  test('extract oversized trace context (Envoy/Istio)', () {
+    final testPropagator = api.W3CTraceContextPropagator();
+    final testCarrier = {};
+
+    // Envoy sidecar (Istio) emits 48-char trace IDs and 24-char span IDs.
+    // The propagator should accept the header and truncate to the rightmost
+    // 32 (trace) / 16 (span) hex characters.
+    TestingInjector()
+      ..set(testCarrier, 'traceparent',
+          '00-00000000000000004bf92f3577b34da6a3ce929d0e0e4736-0000000000f067aa0ba902b7-01');
+    final resultContext = testPropagator.extract(
+        api.Context.current, testCarrier, TestingExtractor());
+    final resultSpan = resultContext.span;
+
+    expect(resultSpan.spanContext.isValid, isTrue);
+    // Rightmost 32 chars of the 48-char trace ID
+    expect(resultSpan.spanContext.traceId.toString(),
+        equals('4bf92f3577b34da6a3ce929d0e0e4736'));
+    // Rightmost 16 chars of the 24-char span ID
+    expect(
+        resultSpan.spanContext.spanId.toString(), equals('00f067aa0ba902b7'));
+    expect(resultSpan.spanContext.traceFlags & api.TraceFlags.sampled,
+        equals(api.TraceFlags.sampled));
+  });
 }

--- a/test/unit/sdk/span_id_test.dart
+++ b/test/unit/sdk/span_id_test.dart
@@ -57,4 +57,16 @@ void main() {
     expect(testSpanId.isValid, true);
     expect(testSpanId.toString(), equals(''));
   });
+
+  test('create from oversized string truncates to rightmost 16 chars', () {
+    // Simulates a non-compliant 24-char span ID produced by a buggy Envoy build
+    // (RT-806: 12-byte span ID encoded as 24 hex chars instead of the required 8 bytes / 16 chars).
+    const oversized = 'df6d1c6ddf796dfe356b4ef7'; // 24 chars
+    final testSpanId = api.SpanId.fromString(oversized);
+
+    expect(testSpanId.toString(), equals('df796dfe356b4ef7'));
+    expect(testSpanId.toString().length, equals(16));
+    expect(testSpanId.get().length, equals(8));
+    expect(testSpanId.isValid, isTrue);
+  });
 }

--- a/test/unit/sdk/trace_id_test.dart
+++ b/test/unit/sdk/trace_id_test.dart
@@ -52,4 +52,18 @@ void main() {
     expect(testTraceId.isValid, isFalse);
     expect(testTraceId.toString(), equals('00000000000000000000000000000000'));
   });
+
+  test('create from oversized string truncates to rightmost 32 chars', () {
+    // Simulates a non-compliant 48-char trace ID produced by a buggy Envoy build
+    // (RT-806: 24-byte trace ID encoded as 48 hex chars instead of the required 16 bytes / 32 chars).
+    // The rightmost 32 chars are kept to preserve the most-significant random bits
+    // that were intended as the 16-byte trace ID.
+    const oversized = 'f38ef66b9eda7b5df8e7971cdfd7b5ddbd5cef7775d7977b'; // 48 chars
+    final testTraceId = api.TraceId.fromString(oversized);
+
+    expect(testTraceId.toString(), equals('f8e7971cdfd7b5ddbd5cef7775d7977b'));
+    expect(testTraceId.toString().length, equals(32));
+    expect(testTraceId.get().length, equals(16));
+    expect(testTraceId.isValid, isTrue);
+  });
 }


### PR DESCRIPTION
## Which problem is this PR solving?

`TraceId.fromString` and `SpanId.fromString` use `padLeft(N, '0')` which pads short strings but **does not truncate strings longer than N**. When Envoy generates non-compliant 48-char trace IDs or 24-char span IDs (a confirmed failure mode in RT-806), the IDs pass through unchanged, violating the W3C TraceContext spec (32/16 hex chars required).

Fixes RT-806.

## Short description of the change

Added a truncation guard to both `fromString` constructors: if the input is longer than the expected size, take the **rightmost N characters** (discarding the leading bytes). This mirrors the common convention in OTel SDKs when forced to accept an oversized ID from a propagation header.

```dart
// Before (pads short, silently passes oversized):
id = id.padLeft(TraceId.sizeBits, '0');

// After (truncates oversized, pads short):
if (id.length > TraceId.sizeBits) {
  id = id.substring(id.length - TraceId.sizeBits);
} else {
  id = id.padLeft(TraceId.sizeBits, '0');
}
```

## How Has This Been Tested?

New unit tests added to `trace_id_test.dart` and `span_id_test.dart` that simulate a 48-char trace ID and a 24-char span ID (as produced by the buggy Envoy build in RT-806), and assert that the rightmost 32/16 chars are preserved.

```
flutter test test/unit/sdk/trace_id_test.dart
flutter test test/unit/sdk/span_id_test.dart
```

## Checklist:

- [x] Unit tests have been added
- [ ] Documentation has been updated